### PR TITLE
bug fixes, and choice of keybindings, feature: can get visual selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,34 @@
 # Git Remote Url:
-This _very_ simple plugin simply maps <leader>yg and <leader> yG to fetch the remote url for main and your current branch respectively.
+This _very_ simple plugin simply contains function to fetch the remote url a git repository.
+
+```lua
+-- defined functions:
+require('git-remote-url').git_url_to_clipboard(optional_branch, optional_path)
+require('git-remote-url').get_git_remote_url(optional_branch, optional_path)
+```
+
+The function can optionally be given a different branch or path as an argument,
+but it will default to the current branch and the current path of the current buffer.
+
+If supplied a different path as argument, it will not include the line selection
+
+There is a function that will return the link, but also one to directly add it to your `+` register!
 
 ## Installation
 Lazy:
 ```lua
 return {
   'JojoMakesGames/git-remote-url.nvim',
-  opts = {}
+  config = function()
+    vim.keymap.set('', '<leader>yg', function()
+      require('git-remote-url').git_url_to_clipboard("main")
+    end, { desc = 'Git Remote Url main branch' })
+    vim.keymap.set('', '<leader>yG', function()
+      require('git-remote-url').git_url_to_clipboard()
+    end, { desc = 'Git Remote Url' })
+  end
 }
 ```
 
 ### Notes:
-This is a very simple plugin that will be recieving updates to follow plugin standards such as not automagically setting keybindings, just wanted to see real quick how easy it was to create a plugin!
-```
+This is a very simple plugin that will be recieving updates to follow plugin standards, just wanted to see real quick how easy it was to create a plugin!

--- a/lua/git-remote-url/init.lua
+++ b/lua/git-remote-url/init.lua
@@ -1,37 +1,82 @@
 local M = {}
-local function build_url(branch)
-	local git_url = vim.fn.system("git config --get remote.origin.url")
+
+local function get_git_url_info(branch, local_path)
+	local isCurrentPath = false
+	local path = local_path
+	if path == nil then
+		isCurrentPath = true
+		path = vim.fn.expand("%")
+		if path == "" then
+			print("No file is open, nor was a path supplied")
+			return
+		end
+	end
+	path = path:gsub("\n", "")
+	if string.find(path, "oil://", 1, true) then
+		path = path:sub(7, -1)
+	end
+	local isDir = (vim.fn.isdirectory(path) == 1)
+	local forgit = path
+	if not isDir then
+		forgit = path:match("(.*[/\\])")
+	end
+	local git_url = vim.fn.system("git -C " .. forgit .. " config --get remote.origin.url"):gsub("\n", "")
 	if git_url == "" then
-		error("Not a git repository")
+		print("Not a git repository")
+		return
+	elseif git_url:sub(-4) == ".git" then
+		git_url = git_url:sub(1, -5)
+	end
+	-- gets the absolute path, then subtracts the git repository root from it and the /.
+	local relgitpath = path:sub(#vim.fn.system("git -C " .. forgit .. " rev-parse --show-toplevel"):gsub("\n", "") + 2)
+	local resolved_branch = branch
+	if resolved_branch == nil then
+		resolved_branch = vim.fn.system("git -C " .. forgit .. " branch --show-current"):gsub("\n", "")
+	end
+	local lnSuffix = ""
+	if not isDir and isCurrentPath then
+		local stsel = vim.fn.line(".")
+		local endsel = vim.fn.line("v")
+		if stsel == endsel then
+			lnSuffix = "#L" .. stsel
+		elseif stsel < endsel then
+			lnSuffix = "#L" .. stsel .. "-L" .. endsel
+		elseif stsel > endsel then
+			lnSuffix = "#L" .. endsel .. "-L" .. stsel
+		end
+	end
+	return {
+		git_url    = git_url,
+		branch     = resolved_branch,
+		relgitpath = relgitpath,
+		lnSuffix   = lnSuffix,
+	}
+end
+
+local function build_git_url(git_url, branch, relgitpath, lnSuffix)
+	if string.find(git_url, "https://github.com", 1, true) then
+		return git_url .. "/blob/" .. branch .. "/" .. relgitpath .. lnSuffix
+	elseif string.find(git_url, "git@github.com", 1, true) then
+		local new_git_url = "https://" .. git_url:sub(5):gsub(":", "/", 1)
+		return new_git_url .. "/blob/" .. branch .. "/" .. relgitpath .. lnSuffix
+	else
+		print("currently only supports github.com links")
 		return
 	end
-	if string.find(git_url, "https://") then
-		git_url = string.sub(git_url, 1, -6)
-	elseif string.find(git_url, "git@") then
-		git_url = "https://github.com/" .. string.sub(git_url, 16, -1)
-	end
+end
 
-	local path = vim.fn.expand("%")
-	local lineNum = vim.api.nvim__buf_stats(0).current_lnum
-	if branch == nil then
-		branch = "main"
-	end
-	local combined = git_url .. "/blob/" .. branch .. "/" .. path .. "#L" .. lineNum
-
+function M.get_git_remote_url(desired_branch, local_path)
+	local url_info = get_git_url_info(desired_branch, local_path) or {}
+	local git_url = url_info.git_url or ""
+	local branch = url_info.branch or ""
+	local relgitpath = url_info.relgitpath or ""
+	local lnSuffix = url_info.lnSuffix or ""
+	local combined = build_git_url(git_url, branch, relgitpath, lnSuffix)
 	return combined
 end
 
-M.setup = function(opts)
-	vim.keymap.set("n", "<leader>yg", function()
-		local combined = build_url()
-		vim.fn.setreg("+", combined)
-	end)
-
-	vim.keymap.set("n", "<leader>yG", function()
-		local branch = string.sub(vim.fn.system("git branch --show-current"), 1, -2)
-		local combined = build_url(branch)
-		vim.fn.setreg("+", combined)
-	end)
+function M.git_url_to_clipboard(desired_branch, local_path)
+	vim.fn.setreg("+", M.get_git_remote_url(desired_branch, local_path))
 end
 
 return M


### PR DESCRIPTION
Added ability to get selection in visual mode

fixed bugs surrounding the presence of .git or not at the end of the link, as well as made it work correctly for oil:// type buffers for those who use the popular oil file manager

broke function up into 2 parts to ease adding of platforms besides github

removed setup function and updated readme to use lazy's config option to set the keybindings instead

removed hard errors, swapped them for prints. can be viewed with :messages if not rendered, or can be swapped back to hard errors
modified:   README.md
modified:   lua/git-remote-url/init.lua