### PR TITLE
same as last PR but with user command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ return {
   opts = {},
   keys = {
     {
-      '<leader>yg', ':CopyGithubLink<CR>'
+      '<leader>yg', ':CopyGithubLink "main"<CR>'
       mode = '', desc = 'Git Remote Url main branch',
     },
     {
-      '<leader>yG', ':CopyGithubLinkWithBranchName<CR>'
+      '<leader>yG', ':CopyGithubLink<CR>'
       mode = '', desc = 'Git Remote Url',
     },
   },

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Git Remote URL:
-This _very_ simple plugin adds the user commands: CopyGithubLink and CopyGithubLinkWithBranchName to fetch the remote URL for main and your current branch respectively.
+This simple plugin adds the user commands: CopyGithubLink and CopyGithubLinkWithBranchName to fetch the remote URL for main and your current branch respectively.
 
 It also exposes 2 functions for use however you like.
 
 ```lua
 -- defined functions:
-require('git-remote-url').git_url_to_clipboard(optional_branch, optional_path)
-require('git-remote-url').get_git_remote_url(optional_branch, optional_path)
+require('git-remote-url').git_url_to_clipboard(optional_branch, optional_path, optional_line_start, optional_line_end)
+require('git-remote-url').get_git_remote_url(optional_branch, optional_path, optional_line_start, optional_line_end)
 ```
 
-The function can optionally be given a different branch or path as an argument,
+The functions can optionally be given a different branch or path as an argument,
 but it will default to the current branch and the current path of the current buffer.
 
 If supplied a branch as argument, it will include the line selection only if it matches the current branch.
@@ -24,20 +24,12 @@ return {
   opts = {},
   keys = {
     {
-      '<leader>yg',
-      function()
-        require('git-remote-url').git_url_to_clipboard("main")
-      end,
-      mode = '',
-      desc = 'Git Remote Url main branch'
+      '<leader>yg', ':CopyGithubLink<CR>'
+      mode = '', desc = 'Git Remote Url main branch',
     },
     {
-      '<leader>yG',
-      function()
-        require('git-remote-url').git_url_to_clipboard()
-      end,
-      mode = '',
-      desc = 'Git Remote Url'
+      '<leader>yG', ':CopyGithubLinkWithBranchName<CR>'
+      mode = '', desc = 'Git Remote Url',
     },
   },
 }
@@ -45,4 +37,3 @@ return {
 
 ### Notes:
 This is a very simple plugin that will be receiving updates, just wanted to see real quick how easy it was to create a plugin!
-```

--- a/README.md
+++ b/README.md
@@ -1,15 +1,48 @@
 # Git Remote URL:
-This _very_ simple plugin adds the commands: CopyGithubLink and CopyGithubLinkWithBranchName to fetch the remote URL for main and your current branch respectively.
+This _very_ simple plugin adds the user commands: CopyGithubLink and CopyGithubLinkWithBranchName to fetch the remote URL for main and your current branch respectively.
+
+It also exposes 2 functions for use however you like.
+
+```lua
+-- defined functions:
+require('git-remote-url').git_url_to_clipboard(optional_branch, optional_path)
+require('git-remote-url').get_git_remote_url(optional_branch, optional_path)
+```
+
+The function can optionally be given a different branch or path as an argument,
+but it will default to the current branch and the current path of the current buffer.
+
+If supplied a branch as argument, it will include the line selection only if it matches the current branch.
+
+If given a path as argument, it will not include the line selection.
 
 ## Installation
 Lazy:
 ```lua
 return {
   'JojoMakesGames/git-remote-url.nvim',
-  opts = {}
+  opts = {},
+  keys = {
+    {
+      '<leader>yg',
+      function()
+        require('git-remote-url').git_url_to_clipboard("main")
+      end,
+      mode = '',
+      desc = 'Git Remote Url main branch'
+    },
+    {
+      '<leader>yG',
+      function()
+        require('git-remote-url').git_url_to_clipboard()
+      end,
+      mode = '',
+      desc = 'Git Remote Url'
+    },
+  },
 }
 ```
 
 ### Notes:
-This is a very simple plugin that will be receiving updates to follow plugin standards such as not automagically setting keybindings, just wanted to see real quick how easy it was to create a plugin!
+This is a very simple plugin that will be receiving updates, just wanted to see real quick how easy it was to create a plugin!
 ```

--- a/lua/git-remote-url/init.lua
+++ b/lua/git-remote-url/init.lua
@@ -40,7 +40,7 @@ local function get_git_url_info(branch, local_path, select_start, select_end)
 	end
 
 	local lnSuffix = ""
-	if not isDir and isCurrentPath and isCurrentBranch then
+	if not isDir and ((isCurrentPath and isCurrentBranch) or (select_start ~= nil and select_end ~= nil)) then
 		local stsel = select_start or vim.fn.line(".")
 		local endsel = select_end or vim.fn.line("v")
 		if stsel == endsel then
@@ -86,11 +86,15 @@ end
 
 M.setup = function(opts)
 	vim.api.nvim_create_user_command('CopyGithubLink', function(args)
-		M.git_url_to_clipboard("main", nil, args.line1, args.line2)
-	end, { range = true })
-
-	vim.api.nvim_create_user_command('CopyGithubLinkWithBranchName', function(args)
-		M.git_url_to_clipboard(nil, nil, args.line1, args.line2)
+		local branch = (args.fargs or {})[1]
+		local path = (args.fargs or {})[2]
+		if branch ~= nil then
+			branch = branch:sub(2, -2)
+		end
+		if path ~= nil then
+			path = path:sub(2, -2)
+		end
+		M.git_url_to_clipboard(branch, path, args.line1, args.line2)
 	end, { range = true })
 end
 


### PR DESCRIPTION
Added ability to get selection in visual mode

fixed bugs surrounding the presence of .git or not at the end of the link, as well as made it work correctly for oil:// type buffers for those who use the popular oil file manager

broke function up into 2 parts to ease adding of platforms besides github

removed hard errors, swapped them for prints. can be viewed with :messages if not rendered, or can be swapped back to hard errors

Added user commands and updated readme